### PR TITLE
code example preview option to render in HTML page

### DIFF
--- a/components/content-plugin/code-example.json
+++ b/components/content-plugin/code-example.json
@@ -1,4 +1,6 @@
 {
+  "connection": "default",
+  "collectionName": "components_content_plugin_code_examples",
   "info": {
     "name": "Code Example",
     "icon": "code"
@@ -13,8 +15,9 @@
     },
     "componentTag": {
       "type": "string"
+    },
+    "preview": {
+      "type": "boolean"
     }
-  },
-  "connection": "default",
-  "collectionName": "components_content_plugin_code_examples"
+  }
 }


### PR DESCRIPTION
Add option in code example components in CMS.
Set to true if code example will be rendered in HTML.